### PR TITLE
Add ability to build binary through Mint Package Manager

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -5,6 +5,7 @@ import PackageDescription
 let package = Package(
     name: "Carting",
     products: [
+        .executable(name: "Carting", targets: ["Carting"]),
         .library(name: "Carting", targets: ["CartingCore"]),
         ],
     dependencies: [

--- a/README.md
+++ b/README.md
@@ -59,6 +59,12 @@ Usage: carting [command] [options]
 $ brew install artemnovichkov/projects/carting
 ```
 
+### [Mint](https://github.com/yonaskolb/Mint):
+
+```bash
+$ mint run artemnovichkov/Carting
+```
+
 ### Make:
 
 ```bash


### PR DESCRIPTION
Mint uses native SPM abilities to build binary and support versioning. 

You can check out the correctness of implementation by running it from my fork like that 

```bash
$ mint run alphatroya/Carting@feature/mint carting update
```