### PR TITLE
Updated dependency URL's and Files v2.3.0

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -3,16 +3,16 @@
     "pins": [
       {
         "package": "Files",
-        "repositoryURL": "https://github.com/johnsundell/files.git",
+        "repositoryURL": "https://github.com/JohnSundell/Files.git",
         "state": {
           "branch": null,
-          "revision": "7de5a7b9627e8f2f88eba8a899ce8ddf2c64d39d",
-          "version": "3.0.0"
+          "revision": "a84615f4558151fab52ac38df697ce2442991f93",
+          "version": "2.3.0"
         }
       },
       {
         "package": "ShellOut",
-        "repositoryURL": "https://github.com/johnsundell/shellout.git",
+        "repositoryURL": "https://github.com/JohnSundell/ShellOut.git",
         "state": {
           "branch": null,
           "revision": "d3d54ce662dfee7fef619330b71d251b8d4869f9",

--- a/Package.swift
+++ b/Package.swift
@@ -9,8 +9,8 @@ let package = Package(
         .library(name: "Carting", targets: ["CartingCore"])
     ],
     dependencies: [
-        .package(url: "https://github.com/johnsundell/files.git", from: "3.0.0"),
-        .package(url: "https://github.com/johnsundell/shellout.git", from: "2.0.0")
+        .package(url: "https://github.com/JohnSundell/Files.git", from: "2.3.0"),
+        .package(url: "https://github.com/JohnSundell/ShellOut.git", from: "2.0.0")
     ],
     targets: [
         .target(name: "Carting", dependencies: ["CartingCore"]),


### PR DESCRIPTION
### Issue Link :link:
- Fixes #41 

### Implementation Details :construction:
- [Fixed] error when running ```swift package update```.

@artemnovichkov NOTE: I updated the version for ```Files``` → "Files now uses Swift 5.0, which makes it [incompatible with toolchains with versions lower than 4.2."](https://github.com/JohnSundell/Files/releases/tag/3.0.0)