### PR TITLE
Support for Application Extensions 

### DIFF
--- a/Sources/CartingCore/Extensions/XcodeProj+Targets.swift
+++ b/Sources/CartingCore/Extensions/XcodeProj+Targets.swift
@@ -5,11 +5,25 @@
 import XcodeProj
 
 extension XcodeProj {
-
+    
     func targets(with type: PBXProductType, name: String?) -> [PBXNativeTarget] {
         return pbxproj.nativeTargets
             .filter { target in
                 guard target.productType == type else {
+                    return false
+                }
+                if let name = name {
+                    return target.name.lowercased() == name.lowercased()
+                }
+                return true
+            }
+    }
+    
+    func targets(with types: [PBXProductType], name: String?) -> [PBXNativeTarget] {
+        return pbxproj.nativeTargets
+            .filter { target in
+                guard let productType = target.productType else { return false }
+                guard types.contains(productType) else {
                     return false
                 }
                 if let name = name {

--- a/Sources/CartingCore/Services/ProjectService.swift
+++ b/Sources/CartingCore/Services/ProjectService.swift
@@ -242,7 +242,7 @@ public final class ProjectService {
     }
 
     private func targets(in project: XcodeProj, withName name: String?) throws -> [PBXNativeTarget] {
-				let filteredTargets = project.targets(with: [.application, .appExtension], name: name)
+        let filteredTargets = project.targets(with: [.application, .appExtension], name: name)
 
         if let name = name, filteredTargets.isEmpty {
             throw Error.targetFilterFailed(name: name)

--- a/Sources/CartingCore/Services/ProjectService.swift
+++ b/Sources/CartingCore/Services/ProjectService.swift
@@ -242,7 +242,7 @@ public final class ProjectService {
     }
 
     private func targets(in project: XcodeProj, withName name: String?) throws -> [PBXNativeTarget] {
-        let filteredTargets = project.targets(with: .application, name: name)
+				let filteredTargets = project.targets(with: [.application, .appExtension], name: name)
 
         if let name = name, filteredTargets.isEmpty {
             throw Error.targetFilterFailed(name: name)


### PR DESCRIPTION
Automatic support for Application Extensions.

I had thought that maybe this should be an option on the command line, but I think that would be a massive nightmare to manage given the large number of possible options, so instead, this is done automatically, in a similar fashion as the .application type.

Consideration for future types might need to be made, but since my needs right now only require supporting Application Extensions, this is as far as I've gone.

Also noted that you can supply a option `targetName` which should help further reduce the need for dedicated command line flags